### PR TITLE
Fix swapped lines and samples in IMRFCA.

### DIFF
--- a/gdal/frmts/nitf/nitfimage.c
+++ b/gdal/frmts/nitf/nitfimage.c
@@ -4316,11 +4316,11 @@ int NITFReadIMRFCA( NITFImage *psImage, NITFRPC00BInfo *psRPC )
 
     for( count = 0; count < 20; ++count )
     {
-        psRPC->LINE_NUM_COEFF[count] = CPLAtof( NITFGetField(szTemp, pachTreIMRFCA, count*22,     22) );
-        psRPC->LINE_DEN_COEFF[count] = CPLAtof( NITFGetField(szTemp, pachTreIMRFCA, 440+count*22, 22) );
+        psRPC->SAMP_NUM_COEFF[count] = CPLAtof( NITFGetField(szTemp, pachTreIMRFCA, count*22,     22) );
+        psRPC->SAMP_DEN_COEFF[count] = CPLAtof( NITFGetField(szTemp, pachTreIMRFCA, 440+count*22, 22) );
 
-        psRPC->SAMP_NUM_COEFF[count] = CPLAtof( NITFGetField(szTemp, pachTreIMRFCA, 880+count*22,  22) );
-        psRPC->SAMP_DEN_COEFF[count] = CPLAtof( NITFGetField(szTemp, pachTreIMRFCA, 1320+count*22, 22) );
+        psRPC->LINE_NUM_COEFF[count] = CPLAtof( NITFGetField(szTemp, pachTreIMRFCA, 880+count*22,  22) );
+        psRPC->LINE_DEN_COEFF[count] = CPLAtof( NITFGetField(szTemp, pachTreIMRFCA, 1320+count*22, 22) );
     }
 
     psRPC->SUCCESS = 1;


### PR DESCRIPTION
Based on table 69 of [MIL-PRF-89034](http://earth-info.nga.mil/publications/specs/printed/89034/89034DPPDB.pdf), IMRFCA RPC coefficients are ordered like this,
```
sample_numerator[20]
sample_denominator[20]
line_numerator[20]
line_denominator[20]
```
The `trunk` is loading them in the wrong order (`lines` then `samples`). This bug impacts any downstream application that uses the RPC coefficients from a DPPDB image.